### PR TITLE
Support mirror

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -22,7 +22,10 @@ var fs = require('graceful-fs')
   , mkdir = require('mkdirp')
   , win = process.platform == 'win32'
   , runtime = semver.parse(process.version).major < 1 ? 'node' : 'iojs'
-  , defaultDisturl = runtime == 'node' ? 'http://nodejs.org/dist' : 'https://iojs.org/dist'
+  , defaultDisturl = runtime == 'node' ?
+      (process.env.NVM_NODEJS_ORG_MIRROR || 'http://nodejs.org/dist')
+      :
+      (process.env.NVM_IOJS_ORG_MIRROR || 'https://iojs.org/dist')
 
 function install (gyp, argv, callback) {
 


### PR DESCRIPTION
Use same env names NVM_NODEJS_ORG_MIRROR and NVM_IOJS_ORG_MIRROR as nvm
